### PR TITLE
Add Preveiw files in Default, Line, Facebook Preview folder.

### DIFF
--- a/ez.ai/client/src/components/ChatbotBuild/Preview/DefaultPreview/AdvancePreview/ListPreview.js
+++ b/ez.ai/client/src/components/ChatbotBuild/Preview/DefaultPreview/AdvancePreview/ListPreview.js
@@ -1,0 +1,56 @@
+import React from "react"
+
+const ListPreview = ({
+  v,
+  i,
+  setVirtualKeyboard,
+  setClickedMainInput,
+  now,
+  setNow,
+  onDelete,
+  changeAvailableIcon
+}) => {
+  return(
+      <div className="main-preview">
+        <div
+          className={now == i ? "main-content listbox-telegram now"
+                              : "main-content listbox-telegram"}
+          key={v.listContent + i}
+          onClick={e => {
+            e.stopPropagation();
+            setVirtualKeyboard(true);
+            setClickedMainInput(v);
+            setNow(i);
+            changeAvailableIcon("list");
+          }}
+        >
+          {" "}
+          <div>
+            <div className="listbox-header-telegram">Question</div>
+            <div className="listbox-question-telegram">
+              {v.listContent.question !== ""
+                ? v.listContent.question
+                : "(Ask a question)"}
+            </div>
+            {v.listContent.elem.map((i) => (
+              v.listContent.elem[i] && 
+                <div className="listbox-elem-telegram">
+                  {v.listContent.elem[i]}
+                </div>
+            ))}
+          </div>
+        </div>
+      <div
+        className="tool-delete delete-listbox "
+        onClick={() => {
+          onDelete(v.id, "list");
+        }}
+      >
+        <i className="fas fa-times"></i>
+      </div>
+    </div>
+              
+  );
+};
+
+export default ListPreview;

--- a/ez.ai/client/src/components/ChatbotBuild/Preview/DefaultPreview/AdvancePreview/VirtualKeyboard.js
+++ b/ez.ai/client/src/components/ChatbotBuild/Preview/DefaultPreview/AdvancePreview/VirtualKeyboard.js
@@ -1,0 +1,59 @@
+import React from 'react';
+import produce from "immer";
+
+const VirtualKeyboard = ({
+  keywordObject, 
+  index, 
+  now,
+  clickedMainInput,
+  currentInput,
+  virtualKeyboard,
+  curListCount,
+  setCurListCount,
+  setKeywordObject,
+}) => {
+    //리스트 요소 삭제
+    const removeListElement = id => {
+      setCurListCount(curListCount.filter(num => num !== id));
+      setKeywordObject(
+        produce(keywordObject, draft => {
+          draft[index].contents[now].listContent.keywordLink[id] = "";
+          draft[index].contents[now].listContent.elem[id] = "";
+        })
+      );
+    };
+  return (
+    <>
+    {virtualKeyboard ? (
+      <div>
+        {(clickedMainInput.type ||
+          (!clickedMainInput.type && currentInput)) &&
+          (currentInput.type === "list" ||
+          clickedMainInput.type === "list" ? (
+            <>
+              <div className="virtual-keyboard">
+                {curListCount.map((i) => (
+                    <div className="list-elem-wrapper">
+                      <span className="list-elem">
+                        {keywordObject[index].contents[now].listContent
+                          .keywordLink[i] || ""}
+                      </span>
+                      <span
+                        className="clear-button"
+                        onClick={() => {
+                          removeListElement(i);
+                        }}
+                      >
+                        x
+                      </span>
+                    </div>
+                ))}
+              </div>
+            </>
+          ) : null)}
+      </div>
+    ) : null}
+    </>
+  )
+}
+export default VirtualKeyboard;

--- a/ez.ai/client/src/components/ChatbotBuild/Preview/DefaultPreview/BasicPreview/AudioPreview.js
+++ b/ez.ai/client/src/components/ChatbotBuild/Preview/DefaultPreview/BasicPreview/AudioPreview.js
@@ -1,0 +1,50 @@
+import React from "react"
+
+const AudioPreview = ({
+  v,
+  i,
+  setClickedMainInput,
+  now,
+  setNow,
+  onDelete,
+  changeAvailableIcon
+}) => {
+  return (
+      <div className="main-preview">
+      <div
+        className={now === i ? "main-content audiobox-telegram now"
+                            : "main-content audiobox-telegram"}
+        key={v.content + i}
+        onClick={() => {
+          setClickedMainInput(v);
+          setNow(i);
+          changeAvailableIcon("audio");
+        }}
+      >
+        {" "}
+        <div>
+          <i className="fas fa-play fa-lg file-icon-telegram"></i>
+          <div className="file-content-telegram">
+            <div className="file-name" data-filetype="">
+              {v.content}
+            </div>
+            <div className="file-size" data-filetype="">
+              {/* 길이, 용량을 표시하려면 데이터를 확장해야함.현재는 파일 이름만 저장 */}
+              {/* 00:00, 00.00 MB{" "} */}
+            </div>
+          </div>
+        </div>
+      </div>
+      <div
+        className="tool-delete delete-audio"
+        onClick={() => {
+          onDelete(v.id);
+        }}
+      >
+        <i className="fas fa-times"></i>
+      </div>
+    </div>
+  );
+};
+
+export default AudioPreview;

--- a/ez.ai/client/src/components/ChatbotBuild/Preview/DefaultPreview/BasicPreview/FilePreview.js
+++ b/ez.ai/client/src/components/ChatbotBuild/Preview/DefaultPreview/BasicPreview/FilePreview.js
@@ -1,0 +1,49 @@
+import React from "react"
+
+const FilePreview = ({
+  v,
+  i,
+  setClickedMainInput,
+  now,
+  setNow,
+  onDelete,
+  changeAvailableIcon
+}) => {
+  return(
+      <div className="main-preview">
+        <div
+          className={now === i ? "main-content filebox-telegram now"
+                              : "main-content filebox-telegram"}
+          key={v.content + i}
+          onClick={() => {
+            setClickedMainInput(v);
+            setNow(i);
+            changeAvailableIcon("file");
+          }}
+        >
+          {" "}
+          <div>
+            <i className="fas fa-file fa-lg file-icon-telegram"></i>
+            <div className="file-content-telegram">
+              <div className="file-name" data-filetype="">
+                {v.content}
+              </div>
+              <div className="file-size" data-filetype="">
+                {/* 00.00 MB */}
+              </div>
+            </div>
+          </div>
+        </div>
+      <div
+        className="tool-delete delete-file"
+        onClick={() => {
+          onDelete(v.id);
+        }}
+      >
+        <i className="fas fa-times"></i>
+      </div>
+    </div>
+  );
+};
+
+export default FilePreview;

--- a/ez.ai/client/src/components/ChatbotBuild/Preview/DefaultPreview/BasicPreview/ImagePreview.js
+++ b/ez.ai/client/src/components/ChatbotBuild/Preview/DefaultPreview/BasicPreview/ImagePreview.js
@@ -1,0 +1,50 @@
+import React from 'react'
+
+const ImagePreview = ({
+  v,
+  i,
+  setClickedMainInput,
+  now,
+  setNow,
+  onDelete,
+  changeAvailableIcon
+}) => {
+  return (
+      <div className="main-preview">
+        <div
+            className={now === i ? "main-content imgbox-telegram now"
+                : "main-content imgbox-telegram"}
+            key={v.content + i}
+            style={{ padding: "1%" }}
+            onClick={(e) => {
+                setClickedMainInput(v);
+                e.stopPropagation();
+                setNow(i);
+                changeAvailableIcon("image");
+            }}
+        >
+            <div>
+                {" "}
+                {v.content !== "" ? (
+                    <div
+                        className="image-preview-telegram"
+                        style={{ backgroundImage: `url(${v.content})` }}
+                    ></div>
+                ) : (
+                    <div className="image-default-telegram">이미지 없음</div>
+                )}
+            </div>
+        </div>
+      <div
+        className="tool-delete delete-image"
+        onClick={() => {
+          onDelete(v.id);
+        }}
+      >
+        <i className="fas fa-times"></i>
+      </div>
+    </div>
+  );
+};
+
+export default ImagePreview;

--- a/ez.ai/client/src/components/ChatbotBuild/Preview/DefaultPreview/BasicPreview/LocationPreview.js
+++ b/ez.ai/client/src/components/ChatbotBuild/Preview/DefaultPreview/BasicPreview/LocationPreview.js
@@ -1,0 +1,55 @@
+import React from "react";
+import GoogleMapPresenter from "../../../api/GoogleMapPresenter";
+
+const LocationPreview = ({
+  v,
+  i,
+  setClickedMainInput,
+  now,
+  setNow,
+  keywordObject,
+  setKeywordObject,
+  index,
+
+  onDelete,
+  changeAvailableIcon,
+}) => {
+  return (
+    <div className="main-preview">
+      <div
+        className={
+          now === i
+            ? "main-content locationbox-telegram now"
+            : "main-content locationbox-telegram"
+        }
+        key={v.content + i}
+        onClick={() => {
+          setClickedMainInput(v);
+          setNow(i);
+          changeAvailableIcon("location");
+        }}
+      >
+        {" "}
+        <div>
+          <GoogleMapPresenter
+            keywordObject={keywordObject}
+            setKeywordObject={setKeywordObject}
+            index={index}
+            now={now}
+          />
+        </div>
+      </div>
+
+      <div
+        className="tool-delete delete-location"
+        onClick={() => {
+          onDelete(v.id);
+        }}
+      >
+        <i className="fas fa-times"></i>
+      </div>
+    </div>
+  );
+};
+
+export default LocationPreview;

--- a/ez.ai/client/src/components/ChatbotBuild/Preview/DefaultPreview/BasicPreview/TextPreview.js
+++ b/ez.ai/client/src/components/ChatbotBuild/Preview/DefaultPreview/BasicPreview/TextPreview.js
@@ -1,0 +1,42 @@
+import React from 'react'
+
+const TextPreview = ({
+  v,
+  i,
+  setClickedMainInput,
+  now,
+  setNow,
+  onDelete,
+  changeAvailableIcon
+}) => {
+  return(
+      <div className="main-preview">
+        <div
+          className={now === i ? "main-content textbox-telegram now"
+                              : "main-content textbox-telegram"}
+          key={v.content + i}
+          style={{padding:'2%'}}
+          onClick={() => {
+            setClickedMainInput(v);
+            setNow(i);
+            changeAvailableIcon("text");
+          }}
+        >
+          <div>
+            {v.content || "(입력)"}
+          </div>
+        </div>
+          <div
+              className="tool-delete delete-text"
+              onClick={() => {
+                  onDelete(v.id);
+              }}
+          >
+              <i className="fas fa-times"></i>
+          </div>
+      </div>
+  );
+
+};
+
+export default TextPreview;

--- a/ez.ai/client/src/components/ChatbotBuild/Preview/DefaultPreview/BasicPreview/VideoPreview.js
+++ b/ez.ai/client/src/components/ChatbotBuild/Preview/DefaultPreview/BasicPreview/VideoPreview.js
@@ -1,0 +1,43 @@
+import React from 'react'
+import TextPreview from "./TextPreview";
+
+const VideoPreview = ({
+  v,
+  i,
+  setClickedMainInput,
+  now,
+  setNow,
+
+  onDelete,
+  changeAvailableIcon
+}) => {
+  return(
+      <div className="main-preview">
+        <div
+          className={now === i ? "main-content videobox-telegram now"
+                              : "main-content videobox-telegram"}
+          key={v.content + i}
+          onClick={() => {
+            setClickedMainInput(v);
+            setNow(i);
+            changeAvailableIcon("video");
+          }}
+        >
+          {" "}
+          <div className="video-content-telegram">
+            <i className="fas fa-play fa-lg file-icon-telegram"></i>
+          </div>
+        </div>
+      <div
+        className="tool-delete delete-video"
+        onClick={() => {
+          onDelete(v.id);
+        }}
+      >
+        <i className="fas fa-times"></i>
+      </div>
+    </div>
+  );
+};
+
+export default VideoPreview;

--- a/ez.ai/client/src/components/ChatbotBuild/Preview/DefaultPreview/DefaultPreview.js
+++ b/ez.ai/client/src/components/ChatbotBuild/Preview/DefaultPreview/DefaultPreview.js
@@ -1,8 +1,107 @@
 import React from "react";
-
-const DefaultPreview = () => {
+import TextPreview from "./BasicPreview/TextPreview";
+import ImagePreview from "./BasicPreview/ImagePreview";
+import VideoPreview from "./BasicPreview/VideoPreview";
+import AudioPreview from "./BasicPreview/AudioPreview";
+import LocationPreview from "./BasicPreview/LocationPreview";
+import FilePreview from "./BasicPreview/FilePreview";
+import ListPreview from "./AdvancePreview/ListPreview";
+import '../TelegramPreview/TelegramPreview.css';
+const DefaultPreview = ({
+  changeAvailableIcon,
+  index,
+  keywordObject,
+  now,
+  onDelete,
+  setClickedMainInput,
+  setKeywordObject,
+  setVirtualKeyboard,
+  setNow,
+}) => {
   return (
     <>
+      {keywordObject[index] && (
+        <div className="main-keyword-title">
+          KEYWORD: {keywordObject[index].keyword}
+        </div>
+      )}
+      {keywordObject[index] &&
+        keywordObject[index].contents.map((v, i) =>
+          v.type === "text" ? (
+            <TextPreview
+              v={v}
+              i={i}
+              setClickedMainInput={setClickedMainInput}
+              now={now}
+              setNow={setNow}
+              onDelete={onDelete}
+              changeAvailableIcon={changeAvailableIcon}
+            />
+          ) : v.type === "image" /**서버에서 파일 받아옴. */ ? (
+            <ImagePreview
+              v={v}
+              i={i}
+              setClickedMainInput={setClickedMainInput}
+              now={now}
+              setNow={setNow}
+              onDelete={onDelete}
+              changeAvailableIcon={changeAvailableIcon}
+            />
+          ) : v.type === "video" /**서버에서 파일 받아옴 */ ? (
+            <VideoPreview
+              v={v}
+              i={i}
+              setClickedMainInput={setClickedMainInput}
+              now={now}
+              setNow={setNow}
+              onDelete={onDelete}
+              changeAvailableIcon={changeAvailableIcon}
+            />
+          ) : v.type === "audio" ? (
+            <AudioPreview
+              v={v}
+              i={i}
+              setClickedMainInput={setClickedMainInput}
+              now={now}
+              setNow={setNow}
+              onDelete={onDelete}
+              changeAvailableIcon={changeAvailableIcon}
+            />
+          ) : v.type === "location" ? (
+            <LocationPreview
+              v={v}
+              i={i}
+              setClickedMainInput={setClickedMainInput}
+              index={index}
+              now={now}
+              setNow={setNow}
+              onDelete={onDelete}
+              keywordObject={keywordObject}
+              setKeywordObject={setKeywordObject}
+              changeAvailableIcon={changeAvailableIcon}
+            />
+          ) : v.type === "file" ? (
+            <FilePreview
+              v={v}
+              i={i}
+              setClickedMainInput={setClickedMainInput}
+              now={now}
+              setNow={setNow}
+              onDelete={onDelete}
+              changeAvailableIcon={changeAvailableIcon}
+            />
+          ) : v.type === "list" ? (
+            <ListPreview
+              v={v}
+              i={i}
+              setVirtualKeyboard={setVirtualKeyboard}
+              setClickedMainInput={setClickedMainInput}
+              now={now}
+              setNow={setNow}
+              onDelete={onDelete}
+              changeAvailableIcon={changeAvailableIcon}
+            />
+          ) : null)}
     </>
   )
 

--- a/ez.ai/client/src/components/ChatbotBuild/Preview/FacebookPreview/AdvancePreview/ListPreview.js
+++ b/ez.ai/client/src/components/ChatbotBuild/Preview/FacebookPreview/AdvancePreview/ListPreview.js
@@ -1,0 +1,56 @@
+import React from "react"
+
+const ListPreview = ({
+  v,
+  i,
+  setVirtualKeyboard,
+  setClickedMainInput,
+  now,
+  setNow,
+  onDelete,
+  changeAvailableIcon
+}) => {
+  return(
+      <div className="main-preview">
+        <div
+          className={now == i ? "main-content listbox-telegram now"
+                              : "main-content listbox-telegram"}
+          key={v.listContent + i}
+          onClick={e => {
+            e.stopPropagation();
+            setVirtualKeyboard(true);
+            setClickedMainInput(v);
+            setNow(i);
+            changeAvailableIcon("list");
+          }}
+        >
+          {" "}
+          <div>
+            <div className="listbox-header-telegram">Question</div>
+            <div className="listbox-question-telegram">
+              {v.listContent.question !== ""
+                ? v.listContent.question
+                : "(Ask a question)"}
+            </div>
+            {v.listContent.elem.map((i) => (
+              v.listContent.elem[i] && 
+                <div className="listbox-elem-telegram">
+                  {v.listContent.elem[i]}
+                </div>
+            ))}
+          </div>
+        </div>
+      <div
+        className="tool-delete delete-listbox "
+        onClick={() => {
+          onDelete(v.id, "list");
+        }}
+      >
+        <i className="fas fa-times"></i>
+      </div>
+    </div>
+              
+  );
+};
+
+export default ListPreview;

--- a/ez.ai/client/src/components/ChatbotBuild/Preview/FacebookPreview/AdvancePreview/VirtualKeyboard.js
+++ b/ez.ai/client/src/components/ChatbotBuild/Preview/FacebookPreview/AdvancePreview/VirtualKeyboard.js
@@ -1,0 +1,59 @@
+import React from 'react';
+import produce from "immer";
+
+const VirtualKeyboard = ({
+  keywordObject, 
+  index, 
+  now,
+  clickedMainInput,
+  currentInput,
+  virtualKeyboard,
+  curListCount,
+  setCurListCount,
+  setKeywordObject,
+}) => {
+    //리스트 요소 삭제
+    const removeListElement = id => {
+      setCurListCount(curListCount.filter(num => num !== id));
+      setKeywordObject(
+        produce(keywordObject, draft => {
+          draft[index].contents[now].listContent.keywordLink[id] = "";
+          draft[index].contents[now].listContent.elem[id] = "";
+        })
+      );
+    };
+  return (
+    <>
+    {virtualKeyboard ? (
+      <div>
+        {(clickedMainInput.type ||
+          (!clickedMainInput.type && currentInput)) &&
+          (currentInput.type === "list" ||
+          clickedMainInput.type === "list" ? (
+            <>
+              <div className="virtual-keyboard">
+                {curListCount.map((i) => (
+                    <div className="list-elem-wrapper">
+                      <span className="list-elem">
+                        {keywordObject[index].contents[now].listContent
+                          .keywordLink[i] || ""}
+                      </span>
+                      <span
+                        className="clear-button"
+                        onClick={() => {
+                          removeListElement(i);
+                        }}
+                      >
+                        x
+                      </span>
+                    </div>
+                ))}
+              </div>
+            </>
+          ) : null)}
+      </div>
+    ) : null}
+    </>
+  )
+}
+export default VirtualKeyboard;

--- a/ez.ai/client/src/components/ChatbotBuild/Preview/FacebookPreview/BasicPreview/AudioPreview.js
+++ b/ez.ai/client/src/components/ChatbotBuild/Preview/FacebookPreview/BasicPreview/AudioPreview.js
@@ -1,0 +1,50 @@
+import React from "react"
+
+const AudioPreview = ({
+  v,
+  i,
+  setClickedMainInput,
+  now,
+  setNow,
+  onDelete,
+  changeAvailableIcon
+}) => {
+  return (
+      <div className="main-preview">
+      <div
+        className={now === i ? "main-content audiobox-telegram now"
+                            : "main-content audiobox-telegram"}
+        key={v.content + i}
+        onClick={() => {
+          setClickedMainInput(v);
+          setNow(i);
+          changeAvailableIcon("audio");
+        }}
+      >
+        {" "}
+        <div>
+          <i className="fas fa-play fa-lg file-icon-telegram"></i>
+          <div className="file-content-telegram">
+            <div className="file-name" data-filetype="">
+              {v.content}
+            </div>
+            <div className="file-size" data-filetype="">
+              {/* 길이, 용량을 표시하려면 데이터를 확장해야함.현재는 파일 이름만 저장 */}
+              {/* 00:00, 00.00 MB{" "} */}
+            </div>
+          </div>
+        </div>
+      </div>
+      <div
+        className="tool-delete delete-audio"
+        onClick={() => {
+          onDelete(v.id);
+        }}
+      >
+        <i className="fas fa-times"></i>
+      </div>
+    </div>
+  );
+};
+
+export default AudioPreview;

--- a/ez.ai/client/src/components/ChatbotBuild/Preview/FacebookPreview/BasicPreview/FilePreview.js
+++ b/ez.ai/client/src/components/ChatbotBuild/Preview/FacebookPreview/BasicPreview/FilePreview.js
@@ -1,0 +1,49 @@
+import React from "react"
+
+const FilePreview = ({
+  v,
+  i,
+  setClickedMainInput,
+  now,
+  setNow,
+  onDelete,
+  changeAvailableIcon
+}) => {
+  return(
+      <div className="main-preview">
+        <div
+          className={now === i ? "main-content filebox-telegram now"
+                              : "main-content filebox-telegram"}
+          key={v.content + i}
+          onClick={() => {
+            setClickedMainInput(v);
+            setNow(i);
+            changeAvailableIcon("file");
+          }}
+        >
+          {" "}
+          <div>
+            <i className="fas fa-file fa-lg file-icon-telegram"></i>
+            <div className="file-content-telegram">
+              <div className="file-name" data-filetype="">
+                {v.content}
+              </div>
+              <div className="file-size" data-filetype="">
+                {/* 00.00 MB */}
+              </div>
+            </div>
+          </div>
+        </div>
+      <div
+        className="tool-delete delete-file"
+        onClick={() => {
+          onDelete(v.id);
+        }}
+      >
+        <i className="fas fa-times"></i>
+      </div>
+    </div>
+  );
+};
+
+export default FilePreview;

--- a/ez.ai/client/src/components/ChatbotBuild/Preview/FacebookPreview/BasicPreview/ImagePreview.js
+++ b/ez.ai/client/src/components/ChatbotBuild/Preview/FacebookPreview/BasicPreview/ImagePreview.js
@@ -1,0 +1,50 @@
+import React from 'react'
+
+const ImagePreview = ({
+  v,
+  i,
+  setClickedMainInput,
+  now,
+  setNow,
+  onDelete,
+  changeAvailableIcon
+}) => {
+  return (
+      <div className="main-preview">
+        <div
+            className={now === i ? "main-content imgbox-telegram now"
+                : "main-content imgbox-telegram"}
+            key={v.content + i}
+            style={{ padding: "1%" }}
+            onClick={(e) => {
+                setClickedMainInput(v);
+                e.stopPropagation();
+                setNow(i);
+                changeAvailableIcon("image");
+            }}
+        >
+            <div>
+                {" "}
+                {v.content !== "" ? (
+                    <div
+                        className="image-preview-telegram"
+                        style={{ backgroundImage: `url(${v.content})` }}
+                    ></div>
+                ) : (
+                    <div className="image-default-telegram">이미지 없음</div>
+                )}
+            </div>
+        </div>
+      <div
+        className="tool-delete delete-image"
+        onClick={() => {
+          onDelete(v.id);
+        }}
+      >
+        <i className="fas fa-times"></i>
+      </div>
+    </div>
+  );
+};
+
+export default ImagePreview;

--- a/ez.ai/client/src/components/ChatbotBuild/Preview/FacebookPreview/BasicPreview/LocationPreview.js
+++ b/ez.ai/client/src/components/ChatbotBuild/Preview/FacebookPreview/BasicPreview/LocationPreview.js
@@ -1,0 +1,55 @@
+import React from "react";
+import GoogleMapPresenter from "../../../api/GoogleMapPresenter";
+
+const LocationPreview = ({
+  v,
+  i,
+  setClickedMainInput,
+  now,
+  setNow,
+  keywordObject,
+  setKeywordObject,
+  index,
+
+  onDelete,
+  changeAvailableIcon,
+}) => {
+  return (
+    <div className="main-preview">
+      <div
+        className={
+          now === i
+            ? "main-content locationbox-telegram now"
+            : "main-content locationbox-telegram"
+        }
+        key={v.content + i}
+        onClick={() => {
+          setClickedMainInput(v);
+          setNow(i);
+          changeAvailableIcon("location");
+        }}
+      >
+        {" "}
+        <div>
+          <GoogleMapPresenter
+            keywordObject={keywordObject}
+            setKeywordObject={setKeywordObject}
+            index={index}
+            now={now}
+          />
+        </div>
+      </div>
+
+      <div
+        className="tool-delete delete-location"
+        onClick={() => {
+          onDelete(v.id);
+        }}
+      >
+        <i className="fas fa-times"></i>
+      </div>
+    </div>
+  );
+};
+
+export default LocationPreview;

--- a/ez.ai/client/src/components/ChatbotBuild/Preview/FacebookPreview/BasicPreview/TextPreview.js
+++ b/ez.ai/client/src/components/ChatbotBuild/Preview/FacebookPreview/BasicPreview/TextPreview.js
@@ -1,0 +1,42 @@
+import React from 'react'
+
+const TextPreview = ({
+  v,
+  i,
+  setClickedMainInput,
+  now,
+  setNow,
+  onDelete,
+  changeAvailableIcon
+}) => {
+  return(
+      <div className="main-preview">
+        <div
+          className={now === i ? "main-content textbox-telegram now"
+                              : "main-content textbox-telegram"}
+          key={v.content + i}
+          style={{padding:'2%'}}
+          onClick={() => {
+            setClickedMainInput(v);
+            setNow(i);
+            changeAvailableIcon("text");
+          }}
+        >
+          <div>
+            {v.content || "(입력)"}
+          </div>
+        </div>
+          <div
+              className="tool-delete delete-text"
+              onClick={() => {
+                  onDelete(v.id);
+              }}
+          >
+              <i className="fas fa-times"></i>
+          </div>
+      </div>
+  );
+
+};
+
+export default TextPreview;

--- a/ez.ai/client/src/components/ChatbotBuild/Preview/FacebookPreview/BasicPreview/VideoPreview.js
+++ b/ez.ai/client/src/components/ChatbotBuild/Preview/FacebookPreview/BasicPreview/VideoPreview.js
@@ -1,0 +1,43 @@
+import React from 'react'
+import TextPreview from "./TextPreview";
+
+const VideoPreview = ({
+  v,
+  i,
+  setClickedMainInput,
+  now,
+  setNow,
+
+  onDelete,
+  changeAvailableIcon
+}) => {
+  return(
+      <div className="main-preview">
+        <div
+          className={now === i ? "main-content videobox-telegram now"
+                              : "main-content videobox-telegram"}
+          key={v.content + i}
+          onClick={() => {
+            setClickedMainInput(v);
+            setNow(i);
+            changeAvailableIcon("video");
+          }}
+        >
+          {" "}
+          <div className="video-content-telegram">
+            <i className="fas fa-play fa-lg file-icon-telegram"></i>
+          </div>
+        </div>
+      <div
+        className="tool-delete delete-video"
+        onClick={() => {
+          onDelete(v.id);
+        }}
+      >
+        <i className="fas fa-times"></i>
+      </div>
+    </div>
+  );
+};
+
+export default VideoPreview;

--- a/ez.ai/client/src/components/ChatbotBuild/Preview/FacebookPreview/FacebookPreview.js
+++ b/ez.ai/client/src/components/ChatbotBuild/Preview/FacebookPreview/FacebookPreview.js
@@ -1,8 +1,107 @@
 import React from "react";
-
-const FacebookPreview = () => {
+import TextPreview from "./BasicPreview/TextPreview";
+import ImagePreview from "./BasicPreview/ImagePreview";
+import VideoPreview from "./BasicPreview/VideoPreview";
+import AudioPreview from "./BasicPreview/AudioPreview";
+import LocationPreview from "./BasicPreview/LocationPreview";
+import FilePreview from "./BasicPreview/FilePreview";
+import ListPreview from "./AdvancePreview/ListPreview";
+import '../TelegramPreview/TelegramPreview.css';
+const FacebookPreview = ({
+  changeAvailableIcon,
+  index,
+  keywordObject,
+  now,
+  onDelete,
+  setClickedMainInput,
+  setKeywordObject,
+  setVirtualKeyboard,
+  setNow,
+}) => {
   return (
     <>
+      {keywordObject[index] && (
+        <div className="main-keyword-title">
+          KEYWORD: {keywordObject[index].keyword}
+        </div>
+      )}
+      {keywordObject[index] &&
+        keywordObject[index].contents.map((v, i) =>
+          v.type === "text" ? (
+            <TextPreview
+              v={v}
+              i={i}
+              setClickedMainInput={setClickedMainInput}
+              now={now}
+              setNow={setNow}
+              onDelete={onDelete}
+              changeAvailableIcon={changeAvailableIcon}
+            />
+          ) : v.type === "image" /**서버에서 파일 받아옴. */ ? (
+            <ImagePreview
+              v={v}
+              i={i}
+              setClickedMainInput={setClickedMainInput}
+              now={now}
+              setNow={setNow}
+              onDelete={onDelete}
+              changeAvailableIcon={changeAvailableIcon}
+            />
+          ) : v.type === "video" /**서버에서 파일 받아옴 */ ? (
+            <VideoPreview
+              v={v}
+              i={i}
+              setClickedMainInput={setClickedMainInput}
+              now={now}
+              setNow={setNow}
+              onDelete={onDelete}
+              changeAvailableIcon={changeAvailableIcon}
+            />
+          ) : v.type === "audio" ? (
+            <AudioPreview
+              v={v}
+              i={i}
+              setClickedMainInput={setClickedMainInput}
+              now={now}
+              setNow={setNow}
+              onDelete={onDelete}
+              changeAvailableIcon={changeAvailableIcon}
+            />
+          ) : v.type === "location" ? (
+            <LocationPreview
+              v={v}
+              i={i}
+              setClickedMainInput={setClickedMainInput}
+              index={index}
+              now={now}
+              setNow={setNow}
+              onDelete={onDelete}
+              keywordObject={keywordObject}
+              setKeywordObject={setKeywordObject}
+              changeAvailableIcon={changeAvailableIcon}
+            />
+          ) : v.type === "file" ? (
+            <FilePreview
+              v={v}
+              i={i}
+              setClickedMainInput={setClickedMainInput}
+              now={now}
+              setNow={setNow}
+              onDelete={onDelete}
+              changeAvailableIcon={changeAvailableIcon}
+            />
+          ) : v.type === "list" ? (
+            <ListPreview
+              v={v}
+              i={i}
+              setVirtualKeyboard={setVirtualKeyboard}
+              setClickedMainInput={setClickedMainInput}
+              now={now}
+              setNow={setNow}
+              onDelete={onDelete}
+              changeAvailableIcon={changeAvailableIcon}
+            />
+          ) : null)}
     </>
   )
 };

--- a/ez.ai/client/src/components/ChatbotBuild/Preview/LinePreview/AdvancePreview/ListPreview.js
+++ b/ez.ai/client/src/components/ChatbotBuild/Preview/LinePreview/AdvancePreview/ListPreview.js
@@ -1,0 +1,56 @@
+import React from "react"
+
+const ListPreview = ({
+  v,
+  i,
+  setVirtualKeyboard,
+  setClickedMainInput,
+  now,
+  setNow,
+  onDelete,
+  changeAvailableIcon
+}) => {
+  return(
+      <div className="main-preview">
+        <div
+          className={now == i ? "main-content listbox-telegram now"
+                              : "main-content listbox-telegram"}
+          key={v.listContent + i}
+          onClick={e => {
+            e.stopPropagation();
+            setVirtualKeyboard(true);
+            setClickedMainInput(v);
+            setNow(i);
+            changeAvailableIcon("list");
+          }}
+        >
+          {" "}
+          <div>
+            <div className="listbox-header-telegram">Question</div>
+            <div className="listbox-question-telegram">
+              {v.listContent.question !== ""
+                ? v.listContent.question
+                : "(Ask a question)"}
+            </div>
+            {v.listContent.elem.map((i) => (
+              v.listContent.elem[i] && 
+                <div className="listbox-elem-telegram">
+                  {v.listContent.elem[i]}
+                </div>
+            ))}
+          </div>
+        </div>
+      <div
+        className="tool-delete delete-listbox "
+        onClick={() => {
+          onDelete(v.id, "list");
+        }}
+      >
+        <i className="fas fa-times"></i>
+      </div>
+    </div>
+              
+  );
+};
+
+export default ListPreview;

--- a/ez.ai/client/src/components/ChatbotBuild/Preview/LinePreview/AdvancePreview/VirtualKeyboard.js
+++ b/ez.ai/client/src/components/ChatbotBuild/Preview/LinePreview/AdvancePreview/VirtualKeyboard.js
@@ -1,0 +1,59 @@
+import React from 'react';
+import produce from "immer";
+
+const VirtualKeyboard = ({
+  keywordObject, 
+  index, 
+  now,
+  clickedMainInput,
+  currentInput,
+  virtualKeyboard,
+  curListCount,
+  setCurListCount,
+  setKeywordObject,
+}) => {
+    //리스트 요소 삭제
+    const removeListElement = id => {
+      setCurListCount(curListCount.filter(num => num !== id));
+      setKeywordObject(
+        produce(keywordObject, draft => {
+          draft[index].contents[now].listContent.keywordLink[id] = "";
+          draft[index].contents[now].listContent.elem[id] = "";
+        })
+      );
+    };
+  return (
+    <>
+    {virtualKeyboard ? (
+      <div>
+        {(clickedMainInput.type ||
+          (!clickedMainInput.type && currentInput)) &&
+          (currentInput.type === "list" ||
+          clickedMainInput.type === "list" ? (
+            <>
+              <div className="virtual-keyboard">
+                {curListCount.map((i) => (
+                    <div className="list-elem-wrapper">
+                      <span className="list-elem">
+                        {keywordObject[index].contents[now].listContent
+                          .keywordLink[i] || ""}
+                      </span>
+                      <span
+                        className="clear-button"
+                        onClick={() => {
+                          removeListElement(i);
+                        }}
+                      >
+                        x
+                      </span>
+                    </div>
+                ))}
+              </div>
+            </>
+          ) : null)}
+      </div>
+    ) : null}
+    </>
+  )
+}
+export default VirtualKeyboard;

--- a/ez.ai/client/src/components/ChatbotBuild/Preview/LinePreview/BasicPreview/AudioPreview.js
+++ b/ez.ai/client/src/components/ChatbotBuild/Preview/LinePreview/BasicPreview/AudioPreview.js
@@ -1,0 +1,50 @@
+import React from "react"
+
+const AudioPreview = ({
+  v,
+  i,
+  setClickedMainInput,
+  now,
+  setNow,
+  onDelete,
+  changeAvailableIcon
+}) => {
+  return (
+      <div className="main-preview">
+      <div
+        className={now === i ? "main-content audiobox-telegram now"
+                            : "main-content audiobox-telegram"}
+        key={v.content + i}
+        onClick={() => {
+          setClickedMainInput(v);
+          setNow(i);
+          changeAvailableIcon("audio");
+        }}
+      >
+        {" "}
+        <div>
+          <i className="fas fa-play fa-lg file-icon-telegram"></i>
+          <div className="file-content-telegram">
+            <div className="file-name" data-filetype="">
+              {v.content}
+            </div>
+            <div className="file-size" data-filetype="">
+              {/* 길이, 용량을 표시하려면 데이터를 확장해야함.현재는 파일 이름만 저장 */}
+              {/* 00:00, 00.00 MB{" "} */}
+            </div>
+          </div>
+        </div>
+      </div>
+      <div
+        className="tool-delete delete-audio"
+        onClick={() => {
+          onDelete(v.id);
+        }}
+      >
+        <i className="fas fa-times"></i>
+      </div>
+    </div>
+  );
+};
+
+export default AudioPreview;

--- a/ez.ai/client/src/components/ChatbotBuild/Preview/LinePreview/BasicPreview/FilePreview.js
+++ b/ez.ai/client/src/components/ChatbotBuild/Preview/LinePreview/BasicPreview/FilePreview.js
@@ -1,0 +1,49 @@
+import React from "react"
+
+const FilePreview = ({
+  v,
+  i,
+  setClickedMainInput,
+  now,
+  setNow,
+  onDelete,
+  changeAvailableIcon
+}) => {
+  return(
+      <div className="main-preview">
+        <div
+          className={now === i ? "main-content filebox-telegram now"
+                              : "main-content filebox-telegram"}
+          key={v.content + i}
+          onClick={() => {
+            setClickedMainInput(v);
+            setNow(i);
+            changeAvailableIcon("file");
+          }}
+        >
+          {" "}
+          <div>
+            <i className="fas fa-file fa-lg file-icon-telegram"></i>
+            <div className="file-content-telegram">
+              <div className="file-name" data-filetype="">
+                {v.content}
+              </div>
+              <div className="file-size" data-filetype="">
+                {/* 00.00 MB */}
+              </div>
+            </div>
+          </div>
+        </div>
+      <div
+        className="tool-delete delete-file"
+        onClick={() => {
+          onDelete(v.id);
+        }}
+      >
+        <i className="fas fa-times"></i>
+      </div>
+    </div>
+  );
+};
+
+export default FilePreview;

--- a/ez.ai/client/src/components/ChatbotBuild/Preview/LinePreview/BasicPreview/ImagePreview.js
+++ b/ez.ai/client/src/components/ChatbotBuild/Preview/LinePreview/BasicPreview/ImagePreview.js
@@ -1,0 +1,50 @@
+import React from 'react'
+
+const ImagePreview = ({
+  v,
+  i,
+  setClickedMainInput,
+  now,
+  setNow,
+  onDelete,
+  changeAvailableIcon
+}) => {
+  return (
+      <div className="main-preview">
+        <div
+            className={now === i ? "main-content imgbox-telegram now"
+                : "main-content imgbox-telegram"}
+            key={v.content + i}
+            style={{ padding: "1%" }}
+            onClick={(e) => {
+                setClickedMainInput(v);
+                e.stopPropagation();
+                setNow(i);
+                changeAvailableIcon("image");
+            }}
+        >
+            <div>
+                {" "}
+                {v.content !== "" ? (
+                    <div
+                        className="image-preview-telegram"
+                        style={{ backgroundImage: `url(${v.content})` }}
+                    ></div>
+                ) : (
+                    <div className="image-default-telegram">이미지 없음</div>
+                )}
+            </div>
+        </div>
+      <div
+        className="tool-delete delete-image"
+        onClick={() => {
+          onDelete(v.id);
+        }}
+      >
+        <i className="fas fa-times"></i>
+      </div>
+    </div>
+  );
+};
+
+export default ImagePreview;

--- a/ez.ai/client/src/components/ChatbotBuild/Preview/LinePreview/BasicPreview/LocationPreview.js
+++ b/ez.ai/client/src/components/ChatbotBuild/Preview/LinePreview/BasicPreview/LocationPreview.js
@@ -1,0 +1,55 @@
+import React from "react";
+import GoogleMapPresenter from "../../../api/GoogleMapPresenter";
+
+const LocationPreview = ({
+  v,
+  i,
+  setClickedMainInput,
+  now,
+  setNow,
+  keywordObject,
+  setKeywordObject,
+  index,
+
+  onDelete,
+  changeAvailableIcon,
+}) => {
+  return (
+    <div className="main-preview">
+      <div
+        className={
+          now === i
+            ? "main-content locationbox-telegram now"
+            : "main-content locationbox-telegram"
+        }
+        key={v.content + i}
+        onClick={() => {
+          setClickedMainInput(v);
+          setNow(i);
+          changeAvailableIcon("location");
+        }}
+      >
+        {" "}
+        <div>
+          <GoogleMapPresenter
+            keywordObject={keywordObject}
+            setKeywordObject={setKeywordObject}
+            index={index}
+            now={now}
+          />
+        </div>
+      </div>
+
+      <div
+        className="tool-delete delete-location"
+        onClick={() => {
+          onDelete(v.id);
+        }}
+      >
+        <i className="fas fa-times"></i>
+      </div>
+    </div>
+  );
+};
+
+export default LocationPreview;

--- a/ez.ai/client/src/components/ChatbotBuild/Preview/LinePreview/BasicPreview/TextPreview.js
+++ b/ez.ai/client/src/components/ChatbotBuild/Preview/LinePreview/BasicPreview/TextPreview.js
@@ -1,0 +1,42 @@
+import React from 'react'
+
+const TextPreview = ({
+  v,
+  i,
+  setClickedMainInput,
+  now,
+  setNow,
+  onDelete,
+  changeAvailableIcon
+}) => {
+  return(
+      <div className="main-preview">
+        <div
+          className={now === i ? "main-content textbox-telegram now"
+                              : "main-content textbox-telegram"}
+          key={v.content + i}
+          style={{padding:'2%'}}
+          onClick={() => {
+            setClickedMainInput(v);
+            setNow(i);
+            changeAvailableIcon("text");
+          }}
+        >
+          <div>
+            {v.content || "(입력)"}
+          </div>
+        </div>
+          <div
+              className="tool-delete delete-text"
+              onClick={() => {
+                  onDelete(v.id);
+              }}
+          >
+              <i className="fas fa-times"></i>
+          </div>
+      </div>
+  );
+
+};
+
+export default TextPreview;

--- a/ez.ai/client/src/components/ChatbotBuild/Preview/LinePreview/BasicPreview/VideoPreview.js
+++ b/ez.ai/client/src/components/ChatbotBuild/Preview/LinePreview/BasicPreview/VideoPreview.js
@@ -1,0 +1,43 @@
+import React from 'react'
+import TextPreview from "./TextPreview";
+
+const VideoPreview = ({
+  v,
+  i,
+  setClickedMainInput,
+  now,
+  setNow,
+
+  onDelete,
+  changeAvailableIcon
+}) => {
+  return(
+      <div className="main-preview">
+        <div
+          className={now === i ? "main-content videobox-telegram now"
+                              : "main-content videobox-telegram"}
+          key={v.content + i}
+          onClick={() => {
+            setClickedMainInput(v);
+            setNow(i);
+            changeAvailableIcon("video");
+          }}
+        >
+          {" "}
+          <div className="video-content-telegram">
+            <i className="fas fa-play fa-lg file-icon-telegram"></i>
+          </div>
+        </div>
+      <div
+        className="tool-delete delete-video"
+        onClick={() => {
+          onDelete(v.id);
+        }}
+      >
+        <i className="fas fa-times"></i>
+      </div>
+    </div>
+  );
+};
+
+export default VideoPreview;

--- a/ez.ai/client/src/components/ChatbotBuild/Preview/LinePreview/LinePreview.js
+++ b/ez.ai/client/src/components/ChatbotBuild/Preview/LinePreview/LinePreview.js
@@ -1,8 +1,108 @@
 import React from "react";
-
-const LinePreview = () => {
+import TextPreview from "./BasicPreview/TextPreview";
+import ImagePreview from "./BasicPreview/ImagePreview";
+import VideoPreview from "./BasicPreview/VideoPreview";
+import AudioPreview from "./BasicPreview/AudioPreview";
+import LocationPreview from "./BasicPreview/LocationPreview";
+import FilePreview from "./BasicPreview/FilePreview";
+import ListPreview from "./AdvancePreview/ListPreview";
+import '../TelegramPreview/TelegramPreview.css';
+const LinePreview = ({
+  changeAvailableIcon,
+  index,
+  keywordObject,
+  now,
+  onDelete,
+  setClickedMainInput,
+  setKeywordObject,
+  setVirtualKeyboard,
+  setNow,
+}) => {
   return (
-    <></>
+    <>
+      {keywordObject[index] && (
+        <div className="main-keyword-title">
+          KEYWORD: {keywordObject[index].keyword}
+        </div>
+      )}
+      {keywordObject[index] &&
+        keywordObject[index].contents.map((v, i) =>
+          v.type === "text" ? (
+            <TextPreview
+              v={v}
+              i={i}
+              setClickedMainInput={setClickedMainInput}
+              now={now}
+              setNow={setNow}
+              onDelete={onDelete}
+              changeAvailableIcon={changeAvailableIcon}
+            />
+          ) : v.type === "image" /**서버에서 파일 받아옴. */ ? (
+            <ImagePreview
+              v={v}
+              i={i}
+              setClickedMainInput={setClickedMainInput}
+              now={now}
+              setNow={setNow}
+              onDelete={onDelete}
+              changeAvailableIcon={changeAvailableIcon}
+            />
+          ) : v.type === "video" /**서버에서 파일 받아옴 */ ? (
+            <VideoPreview
+              v={v}
+              i={i}
+              setClickedMainInput={setClickedMainInput}
+              now={now}
+              setNow={setNow}
+              onDelete={onDelete}
+              changeAvailableIcon={changeAvailableIcon}
+            />
+          ) : v.type === "audio" ? (
+            <AudioPreview
+              v={v}
+              i={i}
+              setClickedMainInput={setClickedMainInput}
+              now={now}
+              setNow={setNow}
+              onDelete={onDelete}
+              changeAvailableIcon={changeAvailableIcon}
+            />
+          ) : v.type === "location" ? (
+            <LocationPreview
+              v={v}
+              i={i}
+              setClickedMainInput={setClickedMainInput}
+              index={index}
+              now={now}
+              setNow={setNow}
+              onDelete={onDelete}
+              keywordObject={keywordObject}
+              setKeywordObject={setKeywordObject}
+              changeAvailableIcon={changeAvailableIcon}
+            />
+          ) : v.type === "file" ? (
+            <FilePreview
+              v={v}
+              i={i}
+              setClickedMainInput={setClickedMainInput}
+              now={now}
+              setNow={setNow}
+              onDelete={onDelete}
+              changeAvailableIcon={changeAvailableIcon}
+            />
+          ) : v.type === "list" ? (
+            <ListPreview
+              v={v}
+              i={i}
+              setVirtualKeyboard={setVirtualKeyboard}
+              setClickedMainInput={setClickedMainInput}
+              now={now}
+              setNow={setNow}
+              onDelete={onDelete}
+              changeAvailableIcon={changeAvailableIcon}
+            />
+          ) : null)}
+    </>
   );
 }
 

--- a/ez.ai/client/src/components/ChatbotBuild/Preview/Preview.css
+++ b/ez.ai/client/src/components/ChatbotBuild/Preview/Preview.css
@@ -39,6 +39,7 @@
 
 /* 프리뷰 메인 가운데 section */
 .main-contents{
+  display:flex;
   height:100%;
   background-size: 100% 100%;
   border: 1px solid #999;
@@ -73,7 +74,7 @@
 .main-contents::-webkit-scrollbar-button {display: none;}
 
 
-.main-keyword-title{ /*== 키워드 말풍선 ==*/
+.main-keyword-title{
   position:relative;
   background-color:#e5ffd0;
   border:1px solid #e5ffd0;
@@ -82,7 +83,8 @@
   width:fit-content;
   word-break:break-all;
   float:right;
-  margin:3%;
+
+  margin: 15px 15px 15px auto;
 }
 
 
@@ -114,7 +116,7 @@
   line-height:20px;
   white-space:pre-wrap;
   border : 2px solid #eee;
-  border-radius: 10px 10px 10px 10px;
+  border-radius: 10px;
   text-align: left;
   clear:right;/*main-keyword-title의 float를 감지하지 않기 위함*/
   min-width:10%;

--- a/ez.ai/client/src/components/ChatbotBuild/Preview/Preview.js
+++ b/ez.ai/client/src/components/ChatbotBuild/Preview/Preview.js
@@ -8,6 +8,7 @@ import DefaultPreview from "./DefaultPreview/DefaultPreview";
 import TelegramPreview from "./TelegramPreview/TelegramPreview";
 import LinePreview from "./LinePreview/LinePreview";
 import FacebookPreview from "./FacebookPreview/FacebookPreview";
+// import Slider from "./Slider";
 
 const Preview = ({
   mainKeyword,
@@ -160,7 +161,17 @@ const Preview = ({
         onClick={ClickedBuilderMain}
       >
       {theme === "default" ? (
-        <DefaultPreview />
+        <DefaultPreview 
+          changeAvailableIcon={changeAvailableIcon}
+          index={index}
+          keywordObject={keywordObject}
+          now={now}
+          onDelete={onDelete}
+          setClickedMainInput={setClickedMainInput}
+          setKeywordObject={setKeywordObject}
+          setVirtualKeyboard={setVirtualKeyboard}
+          setNow={setNow}
+        />
       )
       : theme == "telegram" ? (
         <TelegramPreview 
@@ -176,12 +187,43 @@ const Preview = ({
         />
       )
       : theme == "line" ? (
-        <LinePreview />
+        <LinePreview 
+          changeAvailableIcon={changeAvailableIcon}
+          index={index}
+          keywordObject={keywordObject}
+          now={now}
+          onDelete={onDelete}
+          setClickedMainInput={setClickedMainInput}
+          setKeywordObject={setKeywordObject}
+          setVirtualKeyboard={setVirtualKeyboard}
+          setNow={setNow}
+        />
       )
       : theme == "facebook" ? (
-        <FacebookPreview />
+        <FacebookPreview 
+          changeAvailableIcon={changeAvailableIcon}
+          index={index}
+          keywordObject={keywordObject}
+          now={now}
+          onDelete={onDelete}
+          setClickedMainInput={setClickedMainInput}
+          setKeywordObject={setKeywordObject}
+          setVirtualKeyboard={setVirtualKeyboard}
+          setNow={setNow}
+        />
       )
       : null}
+      {/* {theme !== "telegram"? 
+        <Slider 
+          keywordObject={keywordObject} 
+          index={index}
+          now={now}
+          clickedMainInput={clickedMainInput}
+          currentInput={currentInput}
+          curListCount={curListCount}
+        />
+        : null
+       } */}
 
       </div>
       {theme === "telegram" ?


### PR DESCRIPTION
- 이 작업을 안 하면 라인, 텔레그램, 기본 테마 선택시 그냥 빈(empty) 상태로 나옴
- 구현은 안됐지만 일단 어떤 형태로 구동이 될 것인지 보이기 위해 '임시로' 똑같은 내용의 파일을 복사 붙여넣기 했습니다.
- 각 파일의 내용의 변동은 거의 없습니다. 굳이 있다면 .css 파일 폴더 위치 경로가 TelegramPreview.js만 './Telegram.css' 이고 나머지는 '../TelegramPreview/TelegramPreview.css' 인 점?
- 파일 명도 동일합니다. 상위 카테고리 명이 다르기 때문에 충돌은 없을거라 생각합니다.