### PR TITLE
Delete mainContents CSS 'display:flex'

### DIFF
--- a/ez.ai/client/src/components/ChatbotBuild/Preview/Preview.css
+++ b/ez.ai/client/src/components/ChatbotBuild/Preview/Preview.css
@@ -39,7 +39,6 @@
 
 /* 프리뷰 메인 가운데 section */
 .main-contents{
-  display:flex;
   height:100%;
   background-size: 100% 100%;
   border: 1px solid #999;


### PR DESCRIPTION
- 프리뷰 영역에서 flex로 display를 제거했더니 hover시 말풍선들이 들뜨는 에러가 사라짐