### PR TITLE
Update limit to 4 elements in the sidebar preview line

### DIFF
--- a/ez.ai/client/src/components/ChatbotBuild/Sidebar/SidebarComponents/SidePreview.js
+++ b/ez.ai/client/src/components/ChatbotBuild/Sidebar/SidebarComponents/SidePreview.js
@@ -48,6 +48,9 @@ const SidePreview = (props) => {
 
   //전달받은 키워드 안의 요소들의 타입을 구별후 배열 return
   const addDialogue = (findKeyword, findIndex) => {
+    if (props.activePlatformTab === "platform-line")
+      findKeyword.contents = findKeyword && findKeyword.contents.filter((c) => c.id <= 4);
+      
     const dialogues = findKeyword.contents.map((c, i) => {
       if (c.type === "text")
         return (
@@ -229,18 +232,17 @@ const SidePreview = (props) => {
       setFixedMenu([]);
       setDialogues((prev) => [...prev, sendMessage(i)]);
     },
-    [dialogues, message, currentChatbot]
+    [dialogues, message, currentChatbot, props.activePlatformTab]
   );
 
   const onSubmitPreview = useCallback(
     (e) => {
       e.preventDefault();
-
       //sendMessage 함수로부터 return받은 배열을  dialogues배열에 추가
       setDialogues((prev) => [...prev, sendMessage(message)]);
       setMessage("");
     },
-    [message]
+    [message, props.activePlatformTab]
   );
 
   //일치하는 키워드가 있으면 키워드의 내용을 addDialogue함수로 전달
@@ -280,7 +282,7 @@ const SidePreview = (props) => {
         </>
       );
     },
-    [message, currentChatbot, dialogues]
+    [message, currentChatbot, dialogues, props.activePlatformTab]
   );
   return (
     <>


### PR DESCRIPTION
- addDialogue(키워드 요소들 배열로 반환) 함수 처음에, activePlatformTab이 'Line'이면
=> findKeyword의 contents (배열) 중 id가 4 이하인 요소만 남긴 새 배열로 findKeyword.contents 업뎃

- sendMessage 함수에서도 현재 활성화 된 플랫폼탭이 'Line'인지 구분하기 위해서
=> sendMessage와 sendMessage를 사용하는 다른 (Hooks) useCallback의 의존성 값 배열에 props.activePlatformTab 추가함